### PR TITLE
Fix Safari invalid dates

### DIFF
--- a/src/components/events/event.tsx
+++ b/src/components/events/event.tsx
@@ -7,6 +7,7 @@ import {
   eventRegistrationHasStarted,
   eventRegistraionHasEnded,
   eventHasStarted,
+  getEventDateObject
 } from "../../helpers/events";
 import EventSettingsModal from "./event-settings-modal";
 import { useAuthorizationContext } from "../../contexts/authorization-context";
@@ -26,11 +27,11 @@ const EventCard = (props: EventCardProps) => {
   );
 
   const startDate = useMemo(
-    () => new Date(`${props.event?.start} EST`),
+    () => getEventDateObject(props.event?.start),
     [props.event.start]
   );
   const endDate = useMemo(
-    () => new Date(`${props.event?.end} EST`),
+    () => getEventDateObject(props.event?.end, true),
     [props.event.end]
   );
 

--- a/src/helpers/events.ts
+++ b/src/helpers/events.ts
@@ -10,14 +10,18 @@ export function filterEvents(events: MSREvent[]): MSREvent[] {
   );
 }
 
+export function getEventDateObject(dateString: string, eod: boolean = false): Date {
+  const edtTimezoneOffset = '-04:00';
+  const timeString = eod ? 'T23:59:59.999' : 'T00:00:00.000';
+  return new Date(`${dateString}${timeString}${edtTimezoneOffset}`);
+}
+
 export function eventHasStarted(event: MSREvent): boolean {
-  const startDate = new Date(`${event?.start} 00:00:00 EST`);
-  return startDate < new Date();
+  return getEventDateObject(event?.start) < new Date();
 }
 
 export function eventHasEnded(event: MSREvent): boolean {
-  const endDate = new Date(`${event?.end} 23:59:59 EST`);
-  return endDate < new Date();
+  return getEventDateObject(event?.end, true) < new Date();
 }
 
 export function eventRegistrationHasStarted(event: MSREvent): boolean {

--- a/src/helpers/events.ts
+++ b/src/helpers/events.ts
@@ -11,9 +11,15 @@ export function filterEvents(events: MSREvent[]): MSREvent[] {
 }
 
 export function getEventDateObject(dateString: string, eod: boolean = false): Date {
+  // Event dates are in the format "YYYY-MM-DD"
   const edtTimezoneOffset = '-04:00';
   const timeString = eod ? 'T23:59:59.999' : 'T00:00:00.000';
   return new Date(`${dateString}${timeString}${edtTimezoneOffset}`);
+}
+
+export function getEventRegistrationDateObject(dateString: string): Date {
+  // Registration dates are in the format "YYYY-MM-DD HH:mm" with UTC times
+  return new Date(`${dateString.replace(' ', 'T')}:00Z`);
 }
 
 export function eventHasStarted(event: MSREvent): boolean {
@@ -25,13 +31,11 @@ export function eventHasEnded(event: MSREvent): boolean {
 }
 
 export function eventRegistrationHasStarted(event: MSREvent): boolean {
-  const startDate = new Date(`${event?.registration?.start} UTC`);
-  return startDate < new Date();
+  return getEventRegistrationDateObject(event?.registration?.start) < new Date();
 }
 
 export function eventRegistraionHasEnded(event: MSREvent): boolean {
-  const endDate = new Date(`${event?.registration?.end} UTC`);
-  return endDate < new Date();
+  return getEventRegistrationDateObject(event?.registration?.end) < new Date();
 }
 
 export function getOrganizationEvents(


### PR DESCRIPTION
- Fix "Invalid Date" displaying for events on Safari browser
- Change timezone from EST to EDT